### PR TITLE
Fix validate.ts error on `npm run build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@types/react-router": "^5.1.8",
     "@types/request": "^2.48.5",
     "@types/valid-url": "^1.0.3",
-    "@types/validate.js": "^0.11.0",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",
     "@vercel/ncc": "^0.25.1",


### PR DESCRIPTION
Fixes error on `npm run build`:
> error TS2306: File 'gwa-cli/node_modules/validate.js/validate.d.ts' is not a module.

Warn on `npm install` notes that this version of validate.ts doesn't need to be declared as a dependency, so declaration is removed.