### PR TITLE
Feature/ns to gw - tweak messages in gateway commands

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -60,7 +60,7 @@ func NewConfigSetCmd(ctx *pkg.AppContext) *cobra.Command {
 Exposes some specific config values that can be defined by the user.
 
 %s
-  gateway:         The default gateway used
+  gateway:         The default Gateway (ID) used 
   token:           Use only if you have a token you know is authenticated
   host:            The API host you wish to communicate with
   scheme:          http or https
@@ -110,7 +110,7 @@ $ gwa config set --gateway ns-sampler
 
 	configSetCmd.Flags().String("token", "", "set the authentication token")
 	viper.BindPFlag("api_key", configSetCmd.Flags().Lookup("token"))
-	configSetCmd.Flags().String("gateway", "", "set the gateway")
+	configSetCmd.Flags().String("gateway", "", "set the Gateway (ID)")
 	viper.BindPFlag("gateway", configSetCmd.Flags().Lookup("gateway"))
 	configSetCmd.Flags().String("host", "", "set the host")
 	viper.BindPFlag("host", configSetCmd.Flags().Lookup("host"))

--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -60,7 +60,7 @@ func GatewayListCmd(ctx *pkg.AppContext, buf *bytes.Buffer) *cobra.Command {
 				fmt.Println(
 					heredoc.Doc(`
 						Next Steps:
-						Run gwa login to obtain another auth token
+						Run 'gwa login' to obtain another auth token
 					`),
 				)
 				return err
@@ -255,9 +255,9 @@ func GatewayCurrentCmd(ctx *pkg.AppContext, buf *bytes.Buffer) *cobra.Command {
 
 			if err != nil {
 				if response.StatusCode == http.StatusUnauthorized {
-					return fmt.Errorf("%v\n\nNext steps:\n1. Run gwa gateway list\n2. Check if %s is in the list\n3. If not, run gwa config set gateway <Gateway ID> with a valid Gateway ID", err, ctx.Gateway)
+					return fmt.Errorf("%v\n\nNext steps:\n1. Run 'gwa gateway list'\n2. Check if '%s' is in the list\n3. If not, run 'gwa config set gateway <Gateway ID>' with a valid Gateway ID", err, ctx.Gateway)
 				} else {
-					return fmt.Errorf("%v\n\nNext steps:\nRun gwa login to obtain another auth token", err)
+					return fmt.Errorf("%v\n\nNext steps:\nRun 'gwa login' to obtain another auth token", err)
 				}
 			}
 

--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -73,19 +73,19 @@ func GatewayListCmd(ctx *pkg.AppContext, buf *bytes.Buffer) *cobra.Command {
 
 			if len(response.Data) > 0 {
 				headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
-  				columnFmt := color.New(color.FgYellow).SprintfFunc()
+				columnFmt := color.New(color.FgYellow).SprintfFunc()
 				tbl := table.New("Display Name", "Gateway ID")
 
 				if buf != nil {
 					tbl.WithWriter(buf)
 				}
-				
+
 				tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
 
 				for _, n := range response.Data {
 					tbl.AddRow(n.DisplayName, n.GatewayId)
 				}
-			
+
 				tbl.Print()
 			}
 
@@ -238,10 +238,6 @@ func GatewayCurrentCmd(ctx *pkg.AppContext, buf *bytes.Buffer) *cobra.Command {
 		Short: "Display the current gateway",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if ctx.Gateway == "" {
-				fmt.Println(heredoc.Doc(`
-You can create a gateway by running:
-    $ gwa gateway create
-`))
 				return fmt.Errorf("no gateway has been defined")
 			}
 
@@ -255,31 +251,18 @@ You can create a gateway by running:
 			loader := pkg.NewSpinner()
 			loader.Start()
 			response, err := r.Do()
-			if err != nil {
-				loader.Stop()
-				if response.StatusCode == http.StatusUnauthorized {
-					fmt.Println()
-					fmt.Printf(`Next Steps:
-1. Run gwa gateway list
-2. Check if %s is in the list
-3. If not, run gwa config set gateway <Gateway ID> with a valid Gateway ID
-`, ctx.Gateway)		
-					fmt.Println()
-				} else {
-					fmt.Println()
-					fmt.Println(
-						heredoc.Doc(`
-							Next Steps:
-							Run gwa login to obtain another auth token
-						`),
-					)
-				}
-				return err
-			}
 			loader.Stop()
 
+			if err != nil {
+				if response.StatusCode == http.StatusUnauthorized {
+					return fmt.Errorf("%v\n\nNext steps:\n1. Run gwa gateway list\n2. Check if %s is in the list\n3. If not, run gwa config set gateway <Gateway ID> with a valid Gateway ID", err, ctx.Gateway)
+				} else {
+					return fmt.Errorf("%v\n\nNext steps:\nRun gwa login to obtain another auth token", err)
+				}
+			}
+
 			headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
-  			columnFmt := color.New(color.FgYellow).SprintfFunc()
+			columnFmt := color.New(color.FgYellow).SprintfFunc()
 			tbl := table.New("Display Name", "Gateway ID")
 			if buf != nil {
 				tbl.WithWriter(buf)

--- a/cmd/generateConfig.go
+++ b/cmd/generateConfig.go
@@ -62,9 +62,9 @@ func (o *GenerateConfigOptions) ValidateService(ctx *pkg.AppContext, service str
 	if err != nil {
 		return err
 	}
-	
+
 	loader := pkg.NewSpinner()
-	loader.Prefix = "Checking Service availability: "
+	loader.Suffix = " Checking service availability"
 	loader.Start()
 	response, err := request.Do()
 	if err != nil {
@@ -73,8 +73,9 @@ func (o *GenerateConfigOptions) ValidateService(ctx *pkg.AppContext, service str
 	loader.Stop()
 
 	if !response.Data.Available {
-		return fmt.Errorf("Service %s is already in use. Suggestion: %s", service, response.Data.Suggestion.ServiceName)
+		return fmt.Errorf("Checking service availability: Service %s is already in use. Suggestion: %s", service, response.Data.Suggestion.ServiceName)
 	}
+
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,7 @@ func NewRootCommand(ctx *pkg.AppContext) *cobra.Command {
 	rootCmd.PersistentFlags().BoolVarP(&ctx.Debug, "debug", "D", false, "Print debug information to stdout when the command has exited")
 	rootCmd.PersistentFlags().StringVar(&ctx.ApiHost, "host", ctx.ApiHost, "Set the default host to use for the API")
 	rootCmd.PersistentFlags().StringVar(&ctx.Scheme, "scheme", "", "Use to override default https")
-	rootCmd.PersistentFlags().StringVar(&ctx.Gateway, "gateway", "", "Assign the gateway you would like to use")
+	rootCmd.PersistentFlags().StringVar(&ctx.Gateway, "gateway", "", "Assign the Gateway (ID) you would like to use")
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 
 	return rootCmd


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Expanding on the fixes to #111, this PR includes:
- move the loader for service validation to _before_ the loading message. and make unavailable output more uniform to match loading msg:
![image](https://github.com/user-attachments/assets/eb29879f-267b-423a-abcb-6f8df10b8372)
- show error messages for `gateway current` _before_ the 'Next steps' text. 
  - Previously the next steps showed above the error, which seemed confusing:
    ```
    ❯ gwa gateway current
    
    Next Steps:
    1. Run gwa gateway list
    2. Check if gw-e8689 is in the list
    3. If not, run gwa config set gateway <Gateway ID> with a valid Gateway ID
    
    Error: Missing authorization scope. (403)
    ```

  - this has some knock on effects like:
![image](https://github.com/user-attachments/assets/c4ba0d65-8da2-4369-9a3e-e15d8ba90257)
- tweak 'Next steps' text - adding quotes for commands and gw name

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)