### PR TITLE
Removed org and orgunit prompts from `generate-config` interactive mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ env:
   GWA_API_HOST: api.gov.bc.ca
   GWA_CLIENT_ID: gwa-cli
   GWA_VERSION: v3
+  DEFAULT_ORG: ministry-of-citizens-services
+  DEFAULT_ORG_UNIT: databc
 
 jobs:
   release-tag:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,6 +9,8 @@ env:
   GWA_API_HOST: api.gov.bc.ca
   GWA_CLIENT_ID: gwa-cli
   GWA_VERSION: v3
+  DEFAULT_ORG: ministry-of-citizens-services
+  DEFAULT_ORG_UNIT: databc
 
 jobs:
   release-tag:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,8 @@ builds:
       - -X main.ClientId={{ .Env.GWA_CLIENT_ID }}
       - -X main.ApiVersion={{ .Env.GWA_VERSION }}
       - -X main.Version={{ .Env.CLI_VERSION }}
+      - -X main.DefaultOrg={{ .Env.DEFAULT_ORG }}
+      - -X main.DefaultOrgUnit={{ .Env.DEFAULT_ORG_UNIT }}
   - id: linux
     binary: gwa
     env:
@@ -30,6 +32,8 @@ builds:
       - -X main.ClientId={{ .Env.GWA_CLIENT_ID }}
       - -X main.ApiVersion={{ .Env.GWA_VERSION }}
       - -X main.Version={{ .Env.CLI_VERSION }}
+      - -X main.DefaultOrg={{ .Env.DEFAULT_ORG }}
+      - -X main.DefaultOrgUnit={{ .Env.DEFAULT_ORG_UNIT }}
   - id: windows
     binary: gwa
     env:
@@ -45,6 +49,8 @@ builds:
       - -X main.ClientId={{ .Env.GWA_CLIENT_ID }}
       - -X main.ApiVersion={{ .Env.GWA_VERSION }}
       - -X main.Version={{ .Env.CLI_VERSION }}
+      - -X main.DefaultOrg={{ .Env.DEFAULT_ORG }}
+      - -X main.DefaultOrgUnit={{ .Env.DEFAULT_ORG_UNIT }}
 
 archives:
   - format: zip

--- a/cmd/generateConfig.go
+++ b/cmd/generateConfig.go
@@ -118,8 +118,6 @@ func (o *GenerateConfigOptions) ImportFromForm(m pkg.GenerateModel) tea.Cmd {
 		o.Service = m.Prompts[service].Value
 		o.Template = m.Prompts[template].Value
 		o.Upstream = m.Prompts[upstream].Value
-		o.Organization = m.Prompts[organization].Value
-		o.OrganizationUnit = m.Prompts[orgUnit].Value
 		o.Out = m.Prompts[outfile].Value
 		return pkg.PromptCompleteEvent("")
 	}
@@ -232,13 +230,11 @@ const (
 	service = iota
 	template
 	upstream
-	organization
-	orgUnit
 	outfile
 )
 
 func initGenerateModel(ctx *pkg.AppContext, opts *GenerateConfigOptions) pkg.GenerateModel {
-	var prompts = make([]pkg.PromptField, 6)
+	var prompts = make([]pkg.PromptField, 4)
 
 	prompts[service] = pkg.NewTextInput("Service", "", true)
 	prompts[service].TextInput.Focus()
@@ -262,8 +258,9 @@ func initGenerateModel(ctx *pkg.AppContext, opts *GenerateConfigOptions) pkg.Gen
 		return err
 	}
 
-	prompts[organization] = pkg.NewTextInput("Organization", "", false)
-	prompts[orgUnit] = pkg.NewTextInput("Org Unit", "", false)
+	opts.Organization = "ministry-of-citizens-services"
+	opts.OrganizationUnit = "databc"
+
 	prompts[outfile] = pkg.NewTextInput("Filename", "Must be a YAML file", true)
 	prompts[outfile].TextInput.SetValue("gw-config.yaml")
 	prompts[outfile].Validator = func(input string) error {

--- a/cmd/generateConfig.go
+++ b/cmd/generateConfig.go
@@ -188,8 +188,8 @@ $ gwa generate-config --template client-credentials-shared-idp \
 	generateConfigCmd.Flags().StringVarP(&opts.Template, "template", "t", "", "Name of a pre-defined template (quick-start, client-credentials-shared-idp, kong-httpbin)")
 	generateConfigCmd.Flags().StringVarP(&opts.Service, "service", "s", "", "A unique service subdomain for your vanity url: https://<service>.api.gov.bc.ca")
 	generateConfigCmd.Flags().StringVarP(&opts.Upstream, "upstream", "u", "", "The upstream implementation of the API")
-	generateConfigCmd.Flags().StringVar(&opts.Organization, "org", "ministry-of-citizens-services", "Set the organization")
-	generateConfigCmd.Flags().StringVar(&opts.OrganizationUnit, "org-unit", "databc", "Set the organization unit")
+	generateConfigCmd.Flags().StringVar(&opts.Organization, "org", ctx.DefaultOrg, "Set the organization")
+	generateConfigCmd.Flags().StringVar(&opts.OrganizationUnit, "org-unit", ctx.DefaultOrgUnit, "Set the organization unit")
 	generateConfigCmd.Flags().StringVarP(&opts.Out, "out", "o", "gw-config.yaml", "The file to output the generate config to")
 
 	return generateConfigCmd
@@ -258,8 +258,8 @@ func initGenerateModel(ctx *pkg.AppContext, opts *GenerateConfigOptions) pkg.Gen
 		return err
 	}
 
-	opts.Organization = "ministry-of-citizens-services"
-	opts.OrganizationUnit = "databc"
+	opts.Organization = ctx.DefaultOrg
+	opts.OrganizationUnit = ctx.DefaultOrgUnit
 
 	prompts[outfile] = pkg.NewTextInput("Filename", "Must be a YAML file", true)
 	prompts[outfile].TextInput.SetValue("gw-config.yaml")

--- a/cmd/generateConfig_test.go
+++ b/cmd/generateConfig_test.go
@@ -137,8 +137,8 @@ func TestClientCredentialsGenerator(t *testing.T) {
 
 func TestValidateService_Available(t *testing.T) {
 	ctx := &pkg.AppContext{
-		Gateway: "test-gateway",
-		ApiHost: "api.gov.ca",
+		Gateway:    "test-gateway",
+		ApiHost:    "api.gov.ca",
 		ApiVersion: "v3",
 	}
 	serviceName := "available-service"
@@ -161,8 +161,8 @@ func TestValidateService_Available(t *testing.T) {
 
 func TestValidateService_NotAvailable(t *testing.T) {
 	ctx := &pkg.AppContext{
-		Gateway: "test-gateway",
-		ApiHost: "api.gov.ca",
+		Gateway:    "test-gateway",
+		ApiHost:    "api.gov.ca",
 		ApiVersion: "v3",
 	}
 	serviceName := "unavailable-service"
@@ -202,8 +202,8 @@ func TestQuickStartGenerator(t *testing.T) {
 			Path:   "/post",
 			Scheme: "https",
 		},
-		Organization:     "ministry-of-citizens-services",
-		OrganizationUnit: "databc",
+		Organization:     "ministry-of-kittens-and-puppies",
+		OrganizationUnit: "puppy-wash",
 		Out:              "gw-config.yaml",
 	}
 	err := GenerateConfig(ctx, opts)
@@ -220,4 +220,53 @@ func TestQuickStartGenerator(t *testing.T) {
 	assert.Contains(t, compare, "url: https://httpbin.org/post")
 	assert.Contains(t, compare, "- my-service.dev.api.gov.bc.ca")
 	assert.Contains(t, compare, "paths: [/post]")
+	assert.Contains(t, compare, "organization: ministry-of-kittens-and-puppies")
+	assert.Contains(t, compare, "organizationUnit: puppy-wash")
+}
+
+func TestInteractiveGenerator(t *testing.T) {
+	dir := t.TempDir()
+	ctx := &pkg.AppContext{
+		Cwd:     dir,
+		Gateway: "test-gateway",
+	}
+	opts := &GenerateConfigOptions{
+		Gateway: "test-gateway",
+	}
+
+	// Initialize model and simulate interactive input
+	model := initGenerateModel(ctx, opts)
+	model.Prompts[service].Value = "my-service"
+	model.Prompts[template].Value = "quick-start"
+	model.Prompts[upstream].Value = "https://httpbin.org/post"
+	model.Prompts[outfile].Value = "gw-config.yaml"
+
+	// Import form values
+	_ = opts.ImportFromForm(model)()
+
+	// Parse the upstream URL
+	err := opts.ParseUpstream()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate the config file
+	err = GenerateConfig(ctx, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read and verify the generated file
+	file, err := os.ReadFile(path.Join(ctx.Cwd, opts.Out))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compare := string(file)
+	assert.Contains(t, compare, "name: my-service-dev")
+	assert.Contains(t, compare, "tags: [ns.test-gateway]")
+	assert.Contains(t, compare, "url: https://httpbin.org/post")
+	assert.Contains(t, compare, "- my-service.dev.api.gov.bc.ca")
+	assert.Contains(t, compare, "organization: ministry-of-citizens-services")
+	assert.Contains(t, compare, "organizationUnit: databc")
 }

--- a/cmd/generateConfig_test.go
+++ b/cmd/generateConfig_test.go
@@ -267,6 +267,6 @@ func TestInteractiveGenerator(t *testing.T) {
 	assert.Contains(t, compare, "tags: [ns.test-gateway]")
 	assert.Contains(t, compare, "url: https://httpbin.org/post")
 	assert.Contains(t, compare, "- my-service.dev.api.gov.bc.ca")
-	assert.Contains(t, compare, "organization: ministry-of-citizens-services")
-	assert.Contains(t, compare, "organizationUnit: databc")
+	assert.Contains(t, compare, "organization: "+ctx.DefaultOrg)
+	assert.Contains(t, compare, "organizationUnit: "+ctx.DefaultOrgUnit)
 }

--- a/env.example
+++ b/env.example
@@ -2,3 +2,5 @@ GWA_API_HOST=hostname
 GWA_CLIENT_ID=client_id
 GWA_VERSION=v3
 CLI_VERSION=3.0.0-dev
+DEFAULT_ORG=ministry-of-kittens
+DEFAULT_ORG_UNIT=grooming-division

--- a/justfile
+++ b/justfile
@@ -2,17 +2,17 @@ set dotenv-load
 set positional-arguments
 
 install:
-  go install -ldflags="-X 'main.ApiHost=${GWA_API_HOST}' -X 'main.ClientId=${GWA_CLIENT_ID}' -X 'main.ApiVersion=${GWA_VERSION}' -X 'main.Version=${CLI_VERSION}'"
+  go install -ldflags="-X 'main.ApiHost=${GWA_API_HOST}' -X 'main.ClientId=${GWA_CLIENT_ID}' -X 'main.ApiVersion=${GWA_VERSION}' -X 'main.Version=${CLI_VERSION}' -X 'main.DefaultOrg=${DEFAULT_ORG}' -X 'main.DefaultOrgUnit=${DEFAULT_ORG_UNIT}'"
   echo "gwa-cli installed in bin"
 
 build:
-  go build -o gwa -ldflags="-X 'main.ApiHost=${GWA_API_HOST}' -X 'main.ClientId=${GWA_CLIENT_ID}' -X 'main.ApiVersion=${GWA_VERSION}' -X 'main.Version=${CLI_VERSION}'" main.go
+  go build -o gwa -ldflags="-X 'main.ApiHost=${GWA_API_HOST}' -X 'main.ClientId=${GWA_CLIENT_ID}' -X 'main.ApiVersion=${GWA_VERSION}' -X 'main.Version=${CLI_VERSION}' -X 'main.DefaultOrg=${DEFAULT_ORG}' -X 'main.DefaultOrgUnit=${DEFAULT_ORG_UNIT}'" main.go
 
 release:
-  GWA_API_HOST=${GWA_API_HOST} GWA_CLIENT_ID=${GWA_CLIENT_ID} GWA_VERSION=${GWA_VERSION} CLI_VERSION=${CLI_VERSION} goreleaser release --snapshot --clean
+  GWA_API_HOST=${GWA_API_HOST} GWA_CLIENT_ID=${GWA_CLIENT_ID} GWA_VERSION=${GWA_VERSION} CLI_VERSION=${CLI_VERSION} DEFAULT_ORG=${DEFAULT_ORG} DEFAULT_ORG_UNIT=${DEFAULT_ORG_UNIT} goreleaser release --snapshot --clean  
 
 run *args:
-  go run -ldflags="-X 'main.ApiHost=$GWA_API_HOST' -X 'main.ClientId=$GWA_CLIENT_ID' -X 'main.ApiVersion=$GWA_VERSION' -X 'main.Version=${CLI_VERSION}'" main.go {{args}}
+  go run -ldflags="-X 'main.ApiHost=$GWA_API_HOST' -X 'main.ClientId=$GWA_CLIENT_ID' -X 'main.ApiVersion=$GWA_VERSION' -X 'main.Version=${CLI_VERSION}' -X 'main.DefaultOrg=${DEFAULT_ORG}' -X 'main.DefaultOrgUnit=${DEFAULT_ORG_UNIT}'" main.go {{args}} 
 
 docs:
   go run build/gen-docs.go > docs/gwa-commands.md

--- a/main.go
+++ b/main.go
@@ -10,16 +10,20 @@ import (
 var ApiHost string
 var ApiVersion string
 var ClientId string
+var DefaultOrg string
+var DefaultOrgUnit string
 var Version string
 
 func main() {
 	cwd, _ := os.Getwd()
 	ctx := &pkg.AppContext{
-		ApiHost:    ApiHost,
-		ApiVersion: ApiVersion,
-		ClientId:   ClientId,
-		Cwd:        cwd,
-		Version:    Version,
+		ApiHost:        ApiHost,
+		ApiVersion:     ApiVersion,
+		ClientId:       ClientId,
+		Cwd:            cwd,
+		DefaultOrg:     DefaultOrg,
+		DefaultOrgUnit: DefaultOrgUnit,
+		Version:        Version,
 	}
 	cmd.Execute(ctx)
 }

--- a/pkg/context.go
+++ b/pkg/context.go
@@ -9,17 +9,19 @@ import (
 )
 
 type AppContext struct {
-	ApiHost    string
-	ApiKey     string
-	Auth       AuthDetails
-	ApiVersion string
-	ClientId   string
-	Cwd        string
-	Debug      bool
-	Host       string
-	Gateway    string
-	Scheme     string
-	Version    string
+	ApiHost        string
+	ApiKey         string
+	Auth           AuthDetails
+	ApiVersion     string
+	ClientId       string
+	Cwd            string
+	DefaultOrg     string
+	DefaultOrgUnit string
+	Debug          bool
+	Host           string
+	Gateway        string
+	Scheme         string
+	Version        string
 }
 
 func (a *AppContext) CreateUrl(path string, params interface{}) (string, error) {


### PR DESCRIPTION
# Description

Fixes:
- #127 

No more prompts for org/orgunit in interactive mode. Set default values for org/orgunit (citz/databc).

Also added tests for interactive mode, and updated an old test to validate the use of non-default org/orgunit.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate) - not necessary, the option flags still work as before, no references to interactive mode prompts in tech docs.

## Further comments

Alternatively, we might have kept the interactive org/orgunit prompts and provided default values (user hits ENTER to accept). I think I still prefer that solution but went ahead with what we had agreed upon. I don't mind going back and implementing that if preferred, it's very simple.
