### PR TITLE
APS-4483 Add Support for mandatory S256 pkce for DeviceLogins

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,8 +13,3 @@ jobs:
       - uses: actions/setup-go@v4
       - name: Run Unit Tests
         run: just test
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GWA CLI
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=gwa-cli&metric=alert_status)](https://sonarcloud.io/dashboard?id=gwa-cli)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=bcgov_gwa-cli&metric=alert_status)](https://sonarcloud.io/dashboard?id=bcgov_gwa-cli)
 [![img](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 

--- a/env.example
+++ b/env.example
@@ -1,6 +1,6 @@
 GWA_API_HOST=hostname
 GWA_CLIENT_ID=client_id
 GWA_VERSION=v3
-CLI_VERSION=3.0.0-dev
+CLI_VERSION=3.1.0-dev
 DEFAULT_ORG=ministry-of-kittens
 DEFAULT_ORG_UNIT=grooming-division

--- a/pkg/auth.go
+++ b/pkg/auth.go
@@ -1,6 +1,9 @@
 package pkg
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,6 +16,10 @@ import (
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
+
+const PKCEMethodNone = "None"
+const PKCEMethodPlain = "plain"
+const PKCEMethodS256 = "S256"
 
 var boldText = lipgloss.NewStyle().Bold(true)
 
@@ -42,7 +49,16 @@ func DeviceLogin(ctx *AppContext) error {
 	}
 	Info("Config updated")
 
-	err = deviceLogin(wellKnownConfig, ctx.ClientId, 8)
+	pkceMethod := viper.GetString("pkce_method")
+	// Default to S256 if pkce_method is not set, and allow opting out of PKCE by setting pkce_method to "None"
+	switch pkceMethod {
+	case "":
+		pkceMethod = PKCEMethodS256
+	case PKCEMethodNone:
+		pkceMethod = ""
+	}
+
+	err = deviceLogin(wellKnownConfig, ctx.ClientId, 8, pkceMethod)
 	if err != nil {
 		return err
 	}
@@ -206,9 +222,54 @@ type DeviceData struct {
 	VerificationUriComplete string `json:"verification_uri_complete"`
 }
 
-func deviceLogin(wellKnownConfig WellKnownConfig, clientId string, timeout time.Duration) error {
+func generatePKCECodeVerifier() (string, error) {
+	b := make([]byte, 32)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func generatePKCECodeChallenge(codeVerifier string, pkceMethod string) (string, error) {
+	switch pkceMethod {
+	case PKCEMethodS256, "":
+		sum := sha256.Sum256([]byte(codeVerifier))
+		return base64.RawURLEncoding.EncodeToString(sum[:]), nil
+	case PKCEMethodPlain:
+		return codeVerifier, nil
+	default:
+		return "", fmt.Errorf("unsupported PKCE method: %s", pkceMethod)
+	}
+}
+
+func deviceLogin(wellKnownConfig WellKnownConfig, clientId string, timeout time.Duration, pkceMethod string) error {
+
+	var err error
+
 	data := url.Values{}
 	data.Set("client_id", clientId)
+
+	var codeVerifier string
+	var codeChallenge string
+
+	if pkceMethod != "" {
+
+		data.Set("code_challenge_method", pkceMethod)
+
+		codeVerifier, err = generatePKCECodeVerifier()
+		if err != nil {
+			return err
+		}
+
+		codeChallenge, err = generatePKCECodeChallenge(codeVerifier, pkceMethod)
+		if err != nil {
+			return err
+		}
+
+		data.Set("code_challenge", codeChallenge)
+	}
+
 	URL := wellKnownConfig.DeviceAuthorizationEndpoint
 	request, err := NewApiPost[DeviceData](&AppContext{}, URL, strings.NewReader(data.Encode()))
 	if err != nil {
@@ -229,7 +290,7 @@ func deviceLogin(wellKnownConfig WellKnownConfig, clientId string, timeout time.
 	fmt.Println("\nWaiting for you to complete the login process...")
 
 	for i := 0; i < 60; i++ {
-		err := pollAuthStatus(wellKnownConfig.TokenEndpoint, clientId, response.Data.DeviceCode)
+		err := pollAuthStatus(wellKnownConfig.TokenEndpoint, clientId, response.Data.DeviceCode, codeVerifier)
 		if err == nil {
 			return nil
 		}
@@ -258,11 +319,14 @@ func fetchWellKnown(url string) (WellKnownConfig, error) {
 	return response.Data, nil
 }
 
-func pollAuthStatus(URL string, clientId string, deviceCode string) error {
+func pollAuthStatus(URL string, clientId string, deviceCode string, codeVerifier string) error {
 	data := url.Values{}
 	data.Set("device_code", deviceCode)
 	data.Set("client_id", clientId)
 	data.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+	if codeVerifier != "" {
+		data.Set("code_verifier", codeVerifier)
+	}
 
 	request, err := NewApiPost[TokenResponse](&AppContext{}, URL, strings.NewReader(data.Encode()))
 	if err != nil {

--- a/pkg/auth.go
+++ b/pkg/auth.go
@@ -18,7 +18,6 @@ import (
 )
 
 const PKCEMethodNone = "None"
-const PKCEMethodPlain = "plain"
 const PKCEMethodS256 = "S256"
 
 var boldText = lipgloss.NewStyle().Bold(true)
@@ -236,8 +235,6 @@ func generatePKCECodeChallenge(codeVerifier string, pkceMethod string) (string, 
 	case PKCEMethodS256, "":
 		sum := sha256.Sum256([]byte(codeVerifier))
 		return base64.RawURLEncoding.EncodeToString(sum[:]), nil
-	case PKCEMethodPlain:
-		return codeVerifier, nil
 	default:
 		return "", fmt.Errorf("unsupported PKCE method: %s", pkceMethod)
 	}
@@ -293,6 +290,9 @@ func deviceLogin(wellKnownConfig WellKnownConfig, clientId string, timeout time.
 		err := pollAuthStatus(wellKnownConfig.TokenEndpoint, clientId, response.Data.DeviceCode, codeVerifier)
 		if err == nil {
 			return nil
+		} else if !strings.Contains(err.Error(), "authorization_pending") {
+
+			fmt.Printf("poll %d/60 response: %v\n", i+1, err)
 		}
 		time.Sleep(time.Second * timeout)
 	}

--- a/pkg/auth_test.go
+++ b/pkg/auth_test.go
@@ -183,78 +183,6 @@ func TestDeviceLogin(t *testing.T) {
 	assert.Equal(t, "y6u7i8o9p0", viper.GetString("refresh_token"))
 }
 
-// Tests reflect the Keycloak gwa-cli client PKCE Method being set to S256
-func TestDeviceLogin_PKCERejectedMethods(t *testing.T) {
-	dir := t.TempDir()
-	SetupAuthConfig(dir)
-
-	tests := []struct {
-		name       string
-		pkceMethod string
-		errorDescription string
-	}{
-		{
-			name:       "plain method rejected",
-			pkceMethod: "plain",
-			errorDescription: "Invalid parameter: code challenge method is not matching the configured one",
-		},
-		{
-			name:       "S512 method rejected",
-			pkceMethod: "S512",
-			errorDescription: "Invalid parameter: code challenge method is not matching the configured one",
-		},
-		{
-			name:       "None method rejected",
-			pkceMethod: "",
-			errorDescription: "Missing parameter: code_challenge_method",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			httpmock.Activate()
-			defer httpmock.DeactivateAndReset()
-
-			clientId := "client123"
-			wellKnownConfig := WellKnownConfig{
-				DeviceAuthorizationEndpoint: fmt.Sprintf("https://authz-%s/auth/realms/app/protocol/openid-connect/auth/device", host),
-				TokenEndpoint:               fmt.Sprintf("https://authz-%s/auth/realms/app/protocol/openid-connect/token", host),
-			}
-
-			httpmock.RegisterResponder("POST", wellKnownConfig.DeviceAuthorizationEndpoint, func(r *http.Request) (*http.Response, error) {
-				assert.Equal(t, clientId, r.PostFormValue("client_id"))
-
-				if r.PostFormValue("code_challenge_method") != PKCEMethodS256 || r.PostFormValue("code_challenge") == "" {
-					return httpmock.NewJsonResponse(400, map[string]interface{}{
-						"error":             "invalid_request",
-						"error_description": tt.errorDescription,
-					})
-				}
-
-				return httpmock.NewJsonResponse(200, map[string]interface{}{
-					"device_code":               "1q2w3e4r",
-					"user_code":                 "ABCD-EFGH",
-					"verification_uri":          fmt.Sprintf("https://authz-%s/auth/realms/app/device", host),
-					"verification_uri_complete": fmt.Sprintf("https://authz-%s/auth/realms/app/device?user_code=1q2w3e4r", host),
-					"expires_in":                600,
-					"interval":                  5,
-				})
-			})
-
-			err := deviceLogin(wellKnownConfig, clientId, 0, tt.pkceMethod)
-			assert.Error(t, err)
-		})
-	}
-}
-
-func TestGeneratePKCECodeChallenge_Plain(t *testing.T) {
-	verifier := "test-verifier"
-
-	challenge, err := generatePKCECodeChallenge(verifier, PKCEMethodPlain)
-	assert.NoError(t, err)
-	assert.Equal(t, verifier, challenge)
-}
-
 func TestGeneratePKCECodeChallenge_S256(t *testing.T) {
 	verifier := "test-verifier"
 
@@ -267,7 +195,7 @@ func TestGeneratePKCECodeChallenge_S256(t *testing.T) {
 func TestGeneratePKCECodeChallenge_InvalidMethod(t *testing.T) {
 	verifier := "test-verifier"
 
-	_, err := generatePKCECodeChallenge(verifier, "S512")
+	_, err := generatePKCECodeChallenge(verifier, "plain")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported PKCE method")
 }

--- a/pkg/auth_test.go
+++ b/pkg/auth_test.go
@@ -152,6 +152,8 @@ func TestDeviceLogin(t *testing.T) {
 	deviceCode := "1q2w3e4r"
 	httpmock.RegisterResponder("POST", wellKnownConfig.DeviceAuthorizationEndpoint, func(r *http.Request) (*http.Response, error) {
 		assert.Equal(t, clientId, r.PostFormValue("client_id"))
+		assert.Equal(t, PKCEMethodS256, r.PostFormValue("code_challenge_method"))
+		assert.NotEmpty(t, r.PostFormValue("code_challenge"))
 		return httpmock.NewJsonResponse(200, map[string]interface{}{
 			"device_code":               deviceCode,
 			"user_code":                 "ABCD-EFGH",
@@ -165,6 +167,7 @@ func TestDeviceLogin(t *testing.T) {
 	httpmock.RegisterResponder("POST", wellKnownConfig.TokenEndpoint, func(r *http.Request) (*http.Response, error) {
 		assert.Equal(t, deviceCode, r.FormValue("device_code"))
 		assert.Equal(t, clientId, r.FormValue("client_id"))
+		assert.NotEmpty(t, r.FormValue("code_verifier"))
 		fmt.Println("count", count)
 		if count > 0 {
 			count -= 1
@@ -175,9 +178,98 @@ func TestDeviceLogin(t *testing.T) {
 			"refresh_token": "y6u7i8o9p0",
 		})
 	})
-	deviceLogin(wellKnownConfig, clientId, 0)
+	deviceLogin(wellKnownConfig, clientId, 0, PKCEMethodS256)
 	assert.Equal(t, "q1w2e3r4t5", viper.GetString("api_key"))
 	assert.Equal(t, "y6u7i8o9p0", viper.GetString("refresh_token"))
+}
+
+// Tests reflect the Keycloak gwa-cli client PKCE Method being set to S256
+func TestDeviceLogin_PKCERejectedMethods(t *testing.T) {
+	dir := t.TempDir()
+	SetupAuthConfig(dir)
+
+	tests := []struct {
+		name       string
+		pkceMethod string
+		errorDescription string
+	}{
+		{
+			name:       "plain method rejected",
+			pkceMethod: "plain",
+			errorDescription: "Invalid parameter: code challenge method is not matching the configured one",
+		},
+		{
+			name:       "S512 method rejected",
+			pkceMethod: "S512",
+			errorDescription: "Invalid parameter: code challenge method is not matching the configured one",
+		},
+		{
+			name:       "None method rejected",
+			pkceMethod: "",
+			errorDescription: "Missing parameter: code_challenge_method",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+
+			clientId := "client123"
+			wellKnownConfig := WellKnownConfig{
+				DeviceAuthorizationEndpoint: fmt.Sprintf("https://authz-%s/auth/realms/app/protocol/openid-connect/auth/device", host),
+				TokenEndpoint:               fmt.Sprintf("https://authz-%s/auth/realms/app/protocol/openid-connect/token", host),
+			}
+
+			httpmock.RegisterResponder("POST", wellKnownConfig.DeviceAuthorizationEndpoint, func(r *http.Request) (*http.Response, error) {
+				assert.Equal(t, clientId, r.PostFormValue("client_id"))
+
+				if r.PostFormValue("code_challenge_method") != PKCEMethodS256 || r.PostFormValue("code_challenge") == "" {
+					return httpmock.NewJsonResponse(400, map[string]interface{}{
+						"error":             "invalid_request",
+						"error_description": tt.errorDescription,
+					})
+				}
+
+				return httpmock.NewJsonResponse(200, map[string]interface{}{
+					"device_code":               "1q2w3e4r",
+					"user_code":                 "ABCD-EFGH",
+					"verification_uri":          fmt.Sprintf("https://authz-%s/auth/realms/app/device", host),
+					"verification_uri_complete": fmt.Sprintf("https://authz-%s/auth/realms/app/device?user_code=1q2w3e4r", host),
+					"expires_in":                600,
+					"interval":                  5,
+				})
+			})
+
+			err := deviceLogin(wellKnownConfig, clientId, 0, tt.pkceMethod)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestGeneratePKCECodeChallenge_Plain(t *testing.T) {
+	verifier := "test-verifier"
+
+	challenge, err := generatePKCECodeChallenge(verifier, PKCEMethodPlain)
+	assert.NoError(t, err)
+	assert.Equal(t, verifier, challenge)
+}
+
+func TestGeneratePKCECodeChallenge_S256(t *testing.T) {
+	verifier := "test-verifier"
+
+	challenge, err := generatePKCECodeChallenge(verifier, PKCEMethodS256)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, challenge)
+	assert.NotEqual(t, verifier, challenge)
+}
+
+func TestGeneratePKCECodeChallenge_InvalidMethod(t *testing.T) {
+	verifier := "test-verifier"
+
+	_, err := generatePKCECodeChallenge(verifier, "S512")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported PKCE method")
 }
 
 func TestFetchWellKnown(t *testing.T) {
@@ -221,11 +313,8 @@ func TestPollAuthStatus(t *testing.T) {
 		i += 1
 		return httpmock.NewJsonResponse(401, "")
 	})
-	pollAuthStatus(url, "client123", "ABCD-EFGH")
+	pollAuthStatus(url, "client123", "ABCD-EFGH", "")
 	if i > 2 {
-		// assert.Error(t, err)
-		// } else {
-		// assert.NoError(t, err)
 		assert.Equal(t, "q1w2e3r4t5y6", viper.GetString("api_key"))
 		assert.Equal(t, "r5t6y7u8i9o0", viper.GetString("refresh_token"))
 	}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,5 @@
-sonar.organization=bcgov-oss
-sonar.projectKey=gwa-cli
-#sonar.host.url=https://sonarcloud.io
+sonar.organization=bcgov-sonarcloud
+sonar.projectKey=bcgov_gwa-cli
 
 # relative paths to source directories. More details and properties are described
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/

--- a/test_device_login.sh
+++ b/test_device_login.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load .env if present
+if [ -f ".env" ]; then
+  set -a
+  source .env
+  set +a
+fi
+
+# ---- adjust these ----
+GWA_BIN="${GWA_BIN:-./gwa}"
+GWA_CONFIG="${GWA_CONFIG:-$HOME/.gwa-config.yaml}"
+DEV_HOST="${GWA_API_HOST:-api-gov-bc-ca.dev.api.gov.bc.ca}"
+SCHEME="${SCHEME:-https}"
+CLIENT_ID="${GWA_CLIENT_ID:-gwa-cli}"
+# ----------------------
+
+timestamp() {
+  date +"%Y-%m-%d %H:%M:%S"
+}
+
+log() {
+  printf '[%s] %s\n' "$(timestamp)" "$*"
+}
+
+fail() {
+  log "FAIL: $*"
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+backup_config() {
+  if [ -f "$GWA_CONFIG" ]; then
+    cp "$GWA_CONFIG" "$GWA_CONFIG.bak.pkce-test"
+    log "Backed up config to $GWA_CONFIG.bak.pkce-test"
+  fi
+}
+
+restore_config() {
+  if [ -f "$GWA_CONFIG.bak.pkce-test" ]; then
+    mv -f "$GWA_CONFIG.bak.pkce-test" "$GWA_CONFIG"
+    log "Restored original config"
+  fi
+}
+
+write_config_base() {
+  mkdir -p "$(dirname "$GWA_CONFIG")"
+  cat > "$GWA_CONFIG" <<EOF
+host: $DEV_HOST
+scheme: $SCHEME
+EOF
+}
+
+set_pkce_method() {
+  local method="$1"
+
+  write_config_base
+
+  if [ -n "$method" ]; then
+    cat >> "$GWA_CONFIG" <<EOF
+pkce_method: $method
+EOF
+  fi
+}
+
+run_case() {
+  local label="$1"
+  local method="$2"
+  local expect="$3"
+  local rc
+
+  log "============================================================"
+  log "CASE: $label"
+  log "pkce_method: ${method:-<unset>}"
+  log "expected: $expect"
+
+  set_pkce_method "$method"
+
+  log "Config written to $GWA_CONFIG:"
+  sed 's/^/  /' "$GWA_CONFIG"
+
+  set +e
+  "$GWA_BIN" login
+  rc=$?
+  set -e
+
+  log "exit code: $rc"
+
+  case "$expect" in
+    fail)
+      if [ "$rc" -eq 0 ]; then
+        fail "Case '$label' was expected to fail, but it succeeded. Non-S256 PKCE behavior is more permissive than expected."
+      fi
+      log "Observed failure as expected"
+      ;;
+    interactive-success)
+      if [ "$rc" -ne 0 ]; then
+        fail "Case '$label' was expected to succeed, but it failed with exit code $rc."
+      fi
+      log "Observed success"
+      ;;
+    *)
+      fail "Unknown expectation: $expect"
+      ;;
+  esac
+}
+
+cleanup() {
+  restore_config || true
+}
+trap cleanup EXIT
+
+require_cmd sed
+
+if [ ! -x "$GWA_BIN" ]; then
+  fail "GWA binary not found or not executable: $GWA_BIN. Build it first."
+fi
+
+backup_config
+
+log "Starting PKCE device-login test matrix"
+log "This script enforces the target behavior:"
+log "  unset -> success (CLI defaults to S256)"
+log "  plain -> fail"
+log "  S256 -> success"
+log "  None -> fail"
+log "  S512 -> fail"
+
+run_case "unset pkce_method (CLI default path)" "" "interactive-success"
+run_case "explicit plain" "plain" "fail"
+run_case "explicit S256" "S256" "interactive-success"
+run_case "explicit None" "None" "fail"
+run_case "explicit S512" "S512" "fail"
+
+log "PKCE test matrix complete"


### PR DESCRIPTION
# Description

Initial implementation of DeviceLogin did not use PKCE.  With the Keycloak 26 update we will begin enforcing S256 PCKE for the gwa-cli client.  The DeviceLogin has been updated to support both plain and S256 PKCE, no PKCE, but use S256 by default.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have checked that unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

Tests reflect the Keycloak gwa-cli client PKCE Method being set to S256
