### PR TITLE
Set `User-Agent` header to `gwa-cli/<version>` 

### DIFF
--- a/pkg/api.go
+++ b/pkg/api.go
@@ -31,6 +31,7 @@ func (m *NewApi[T]) New() (*NewApi[T], error) {
 	}
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Accepts", "application/json")
+	request.Header.Set("User-Agent", fmt.Sprintf("gwa-cli/%s", m.ctx.Version))
 
 	m.Request = request
 

--- a/pkg/auth.go
+++ b/pkg/auth.go
@@ -22,6 +22,14 @@ const PKCEMethodS256 = "S256"
 
 var boldText = lipgloss.NewStyle().Bold(true)
 
+// newAuthRequestContext returns a minimal AppContext for auth-flow HTTP requests.
+// It intentionally omits ApiKey (to avoid sending a stale Bearer token to auth
+// endpoints) and other stateful fields, while preserving Version so the
+// User-Agent header is still set correctly.
+func newAuthRequestContext(ctx *AppContext) *AppContext {
+	return &AppContext{Version: ctx.Version}
+}
+
 func DeviceLogin(ctx *AppContext) error {
 	Info("Auth: Device login selected")
 	openApiPathname, err := fetchConfigUrl(ctx)
@@ -36,7 +44,7 @@ func DeviceLogin(ctx *AppContext) error {
 	}
 	Info("Auth token recieved")
 
-	wellKnownConfig, err := fetchWellKnown(authTokenUrl)
+	wellKnownConfig, err := fetchWellKnown(ctx, authTokenUrl)
 	if err != nil {
 		return err
 	}
@@ -57,7 +65,7 @@ func DeviceLogin(ctx *AppContext) error {
 		pkceMethod = ""
 	}
 
-	err = deviceLogin(wellKnownConfig, ctx.ClientId, 8, pkceMethod)
+	err = deviceLogin(ctx, wellKnownConfig, ctx.ClientId, 8, pkceMethod)
 	if err != nil {
 		return err
 	}
@@ -80,7 +88,7 @@ func ClientCredentialsLogin(ctx *AppContext, clientId string, clientSecret strin
 	}
 	Info("Auth token recieved")
 
-	wellKnownConfig, err := fetchWellKnown(authTokenUrl)
+	wellKnownConfig, err := fetchWellKnown(ctx, authTokenUrl)
 	if err != nil {
 		return err
 	}
@@ -92,7 +100,7 @@ func ClientCredentialsLogin(ctx *AppContext, clientId string, clientSecret strin
 	}
 	Info("Config updated")
 
-	err = ClientCredentialLogin(wellKnownConfig.TokenEndpoint, clientId, clientSecret)
+	err = ClientCredentialLogin(ctx, wellKnownConfig.TokenEndpoint, clientId, clientSecret)
 	if err != nil {
 		return err
 	}
@@ -240,7 +248,7 @@ func generatePKCECodeChallenge(codeVerifier string, pkceMethod string) (string, 
 	}
 }
 
-func deviceLogin(wellKnownConfig WellKnownConfig, clientId string, timeout time.Duration, pkceMethod string) error {
+func deviceLogin(ctx *AppContext, wellKnownConfig WellKnownConfig, clientId string, timeout time.Duration, pkceMethod string) error {
 
 	var err error
 
@@ -268,7 +276,7 @@ func deviceLogin(wellKnownConfig WellKnownConfig, clientId string, timeout time.
 	}
 
 	URL := wellKnownConfig.DeviceAuthorizationEndpoint
-	request, err := NewApiPost[DeviceData](&AppContext{}, URL, strings.NewReader(data.Encode()))
+	request, err := NewApiPost[DeviceData](newAuthRequestContext(ctx), URL, strings.NewReader(data.Encode()))
 	if err != nil {
 		return err
 	}
@@ -287,7 +295,7 @@ func deviceLogin(wellKnownConfig WellKnownConfig, clientId string, timeout time.
 	fmt.Println("\nWaiting for you to complete the login process...")
 
 	for i := 0; i < 60; i++ {
-		err := pollAuthStatus(wellKnownConfig.TokenEndpoint, clientId, response.Data.DeviceCode, codeVerifier)
+		err := pollAuthStatus(ctx, wellKnownConfig.TokenEndpoint, clientId, response.Data.DeviceCode, codeVerifier)
 		if err == nil {
 			return nil
 		} else if !strings.Contains(err.Error(), "authorization_pending") {
@@ -306,8 +314,8 @@ type WellKnownConfig struct {
 	DeviceAuthorizationEndpoint string `json:"device_authorization_endpoint"`
 }
 
-func fetchWellKnown(url string) (WellKnownConfig, error) {
-	request, err := NewApiGet[WellKnownConfig](&AppContext{}, url)
+func fetchWellKnown(ctx *AppContext, url string) (WellKnownConfig, error) {
+	request, err := NewApiGet[WellKnownConfig](newAuthRequestContext(ctx), url)
 	if err != nil {
 		return WellKnownConfig{}, err
 	}
@@ -319,7 +327,7 @@ func fetchWellKnown(url string) (WellKnownConfig, error) {
 	return response.Data, nil
 }
 
-func pollAuthStatus(URL string, clientId string, deviceCode string, codeVerifier string) error {
+func pollAuthStatus(ctx *AppContext, URL string, clientId string, deviceCode string, codeVerifier string) error {
 	data := url.Values{}
 	data.Set("device_code", deviceCode)
 	data.Set("client_id", clientId)
@@ -328,7 +336,7 @@ func pollAuthStatus(URL string, clientId string, deviceCode string, codeVerifier
 		data.Set("code_verifier", codeVerifier)
 	}
 
-	request, err := NewApiPost[TokenResponse](&AppContext{}, URL, strings.NewReader(data.Encode()))
+	request, err := NewApiPost[TokenResponse](newAuthRequestContext(ctx), URL, strings.NewReader(data.Encode()))
 	if err != nil {
 		return err
 	}
@@ -399,13 +407,12 @@ func RefreshToken(ctx *AppContext) error {
 	return errorResponse.GetError()
 }
 
-func ClientCredentialLogin(tokenEndpoint string, clientId string, clientSecret string) error {
+func ClientCredentialLogin(ctx *AppContext, tokenEndpoint string, clientId string, clientSecret string) error {
 	data := make(url.Values)
 	data.Set("client_id", clientId)
 	data.Set("client_secret", clientSecret)
 	data.Set("grant_type", "client_credentials")
-	ctx := &AppContext{}
-	r, err := NewApiPost[TokenResponse](ctx, tokenEndpoint, strings.NewReader(data.Encode()))
+	r, err := NewApiPost[TokenResponse](newAuthRequestContext(ctx), tokenEndpoint, strings.NewReader(data.Encode()))
 	if err != nil {
 		return err
 	}

--- a/pkg/auth_test.go
+++ b/pkg/auth_test.go
@@ -150,7 +150,10 @@ func TestDeviceLogin(t *testing.T) {
 	}
 	verificationUrl := fmt.Sprintf("https://authz-%s/auth/realms/app/device", host)
 	deviceCode := "1q2w3e4r"
+	expectedUA := "gwa-cli/v3.0.0-test"
 	httpmock.RegisterResponder("POST", wellKnownConfig.DeviceAuthorizationEndpoint, func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, expectedUA, r.Header.Get("User-Agent"))
+		assert.Empty(t, r.Header.Get("Authorization"), "auth device request must not reuse ApiKey from AppContext")
 		assert.Equal(t, clientId, r.PostFormValue("client_id"))
 		assert.Equal(t, PKCEMethodS256, r.PostFormValue("code_challenge_method"))
 		assert.NotEmpty(t, r.PostFormValue("code_challenge"))
@@ -165,6 +168,8 @@ func TestDeviceLogin(t *testing.T) {
 	})
 	count := 2
 	httpmock.RegisterResponder("POST", wellKnownConfig.TokenEndpoint, func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, expectedUA, r.Header.Get("User-Agent"))
+		assert.Empty(t, r.Header.Get("Authorization"), "auth token poll must not reuse ApiKey from AppContext")
 		assert.Equal(t, deviceCode, r.FormValue("device_code"))
 		assert.Equal(t, clientId, r.FormValue("client_id"))
 		assert.NotEmpty(t, r.FormValue("code_verifier"))
@@ -178,7 +183,10 @@ func TestDeviceLogin(t *testing.T) {
 			"refresh_token": "y6u7i8o9p0",
 		})
 	})
-	deviceLogin(&AppContext{}, wellKnownConfig, clientId, 0, PKCEMethodS256)
+	deviceLogin(&AppContext{
+		Version: "v3.0.0-test",
+		ApiKey:  "stale-access-token-should-not-be-sent",
+	}, wellKnownConfig, clientId, 0, PKCEMethodS256)
 	assert.Equal(t, "q1w2e3r4t5", viper.GetString("api_key"))
 	assert.Equal(t, "y6u7i8o9p0", viper.GetString("refresh_token"))
 }
@@ -217,6 +225,61 @@ func TestFetchWellKnown(t *testing.T) {
 		DeviceAuthorizationEndpoint: fmt.Sprintf("https://authz-%s/auth/realms/app/protocol/openid-connect/auth/device", host),
 		TokenEndpoint:               fmt.Sprintf("https://authz-%s/auth/realms/app/protocol/openid-connect/token", host),
 	}, result)
+}
+
+// TestFetchWellKnown_NewAuthRequestContextHeaders ensures auth HTTP uses Version for User-Agent
+// and does not forward ApiKey as Authorization (newAuthRequestContext).
+func TestFetchWellKnown_NewAuthRequestContextHeaders(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	url := "https://auth.example/.well-known/openid-configuration"
+	expectedUA := "gwa-cli/v9.9.9"
+
+	httpmock.RegisterResponder("GET", url, func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, expectedUA, r.Header.Get("User-Agent"))
+		assert.Empty(t, r.Header.Get("Authorization"), "well-known fetch must not reuse ApiKey from AppContext")
+		return httpmock.NewJsonResponse(200, map[string]interface{}{
+			"device_authorization_endpoint": "https://auth.example/device",
+			"token_endpoint":                "https://auth.example/token",
+		})
+	})
+
+	ctx := &AppContext{
+		Version: "v9.9.9",
+		ApiKey:  "stale-access-token-should-not-be-sent",
+	}
+	_, err := fetchWellKnown(ctx, url)
+	assert.NoError(t, err)
+}
+
+// TestPollAuthStatus_NewAuthRequestContextHeaders ensures auth HTTP uses Version for User-Agent
+// and does not forward ApiKey as Authorization (newAuthRequestContext).
+func TestPollAuthStatus_NewAuthRequestContextHeaders(t *testing.T) {
+	dir := t.TempDir()
+	SetupAuthConfig(dir)
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	tokenURL := "https://auth.example/token"
+	expectedUA := "gwa-cli/v1.2.3"
+
+	httpmock.RegisterResponder("POST", tokenURL, func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, expectedUA, r.Header.Get("User-Agent"))
+		assert.Empty(t, r.Header.Get("Authorization"), "token poll must not reuse ApiKey from AppContext")
+		return httpmock.NewJsonResponse(200, map[string]interface{}{
+			"access_token":       "abc",
+			"refresh_token":      "def",
+			"refresh_expires_in": 3600,
+		})
+	})
+
+	ctx := &AppContext{
+		Version: "v1.2.3",
+		ApiKey:  "stale-access-token-should-not-be-sent",
+	}
+	err := pollAuthStatus(ctx, tokenURL, "gwa-cli", "device-code", "verifier")
+	assert.NoError(t, err)
 }
 
 func TestPollAuthStatus(t *testing.T) {
@@ -300,7 +363,10 @@ func TestClientCredentialLogin(t *testing.T) {
 
 	apiKey := "12ad54kl"
 	refreshToken := "34fg78hj"
+	expectedUA := "gwa-cli/v2.0.0-cc"
 	httpmock.RegisterResponder("POST", tokenUrl, func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, expectedUA, r.Header.Get("User-Agent"))
+		assert.Empty(t, r.Header.Get("Authorization"), "client-credentials token request must not reuse ApiKey from AppContext")
 		assert.Equal(t, "client123", r.FormValue("client_id"))
 		assert.Equal(t, "$3cr3t", r.FormValue("client_secret"))
 		assert.Equal(t, "client_credentials", r.FormValue("grant_type"))
@@ -311,7 +377,10 @@ func TestClientCredentialLogin(t *testing.T) {
 			"refresh_expires_in": 0,
 		})
 	})
-	ClientCredentialLogin(&AppContext{}, tokenUrl, "client123", "$3cr3t")
+	ClientCredentialLogin(&AppContext{
+		Version: "v2.0.0-cc",
+		ApiKey:  "stale-access-token-should-not-be-sent",
+	}, tokenUrl, "client123", "$3cr3t")
 
 	assert.Equal(t, viper.GetString("api_key"), apiKey)
 	assert.Equal(t, viper.GetString("refresh_token"), refreshToken)

--- a/pkg/auth_test.go
+++ b/pkg/auth_test.go
@@ -178,7 +178,7 @@ func TestDeviceLogin(t *testing.T) {
 			"refresh_token": "y6u7i8o9p0",
 		})
 	})
-	deviceLogin(wellKnownConfig, clientId, 0, PKCEMethodS256)
+	deviceLogin(&AppContext{}, wellKnownConfig, clientId, 0, PKCEMethodS256)
 	assert.Equal(t, "q1w2e3r4t5", viper.GetString("api_key"))
 	assert.Equal(t, "y6u7i8o9p0", viper.GetString("refresh_token"))
 }
@@ -211,7 +211,7 @@ func TestFetchWellKnown(t *testing.T) {
 			"token_endpoint":                fmt.Sprintf("https://authz-%s/auth/realms/app/protocol/openid-connect/token", host),
 		})
 	})
-	result, err := fetchWellKnown(url)
+	result, err := fetchWellKnown(&AppContext{}, url)
 	assert.NoError(t, err)
 	assert.Equal(t, WellKnownConfig{
 		DeviceAuthorizationEndpoint: fmt.Sprintf("https://authz-%s/auth/realms/app/protocol/openid-connect/auth/device", host),
@@ -241,7 +241,7 @@ func TestPollAuthStatus(t *testing.T) {
 		i += 1
 		return httpmock.NewJsonResponse(401, "")
 	})
-	pollAuthStatus(url, "client123", "ABCD-EFGH", "")
+	pollAuthStatus(&AppContext{}, url, "client123", "ABCD-EFGH", "")
 	if i > 2 {
 		assert.Equal(t, "q1w2e3r4t5y6", viper.GetString("api_key"))
 		assert.Equal(t, "r5t6y7u8i9o0", viper.GetString("refresh_token"))
@@ -311,7 +311,7 @@ func TestClientCredentialLogin(t *testing.T) {
 			"refresh_expires_in": 0,
 		})
 	})
-	ClientCredentialLogin(tokenUrl, "client123", "$3cr3t")
+	ClientCredentialLogin(&AppContext{}, tokenUrl, "client123", "$3cr3t")
 
 	assert.Equal(t, viper.GetString("api_key"), apiKey)
 	assert.Equal(t, viper.GetString("refresh_token"), refreshToken)


### PR DESCRIPTION
# Description

Sets the `User-Agent` header to `gwa-cli/<version>` on all HTTP requests.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

The login flow was creating empty `&AppContext{}` instances, causing the version to be empty in the `User-Agent` header on auth endpoints. It seems potentially beneficial for auth to not use the real context since it could lead to stale auth tokens being reused. To keep the clean empty auth context and include the version, I added `newAuthRequestContext()` helper that preserves Version but strips other state, which is passed to auth functions.
